### PR TITLE
docs: add Code of Conduct

### DIFF
--- a/CODEOFCONDUCT.MD
+++ b/CODEOFCONDUCT.MD
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+All contributors and maintainers of this project are subject to this code of conduct. 
+
+We pledge to respect everyone who contributes to this project or other associated activities with 'yourfirstpr' by (including but not limited to) creating project issues, submitting pull requests and providing feedback by way of comments and communicating to the @yourfirstpr Twitter account. Everyone who engages with the project through other channels, will also receive that same respect.
+
+Unacceptable behaviour includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+
+If anyone within the 'yourfirstpr' community fails to adhere to this Code of Conduct then they can expect to face action by way of: removing comments, removing issues, deleting pull requests and being banned from contributing to the 'yourfirstpr' community.
+
+If a member of the 'yourfirstpr' community behaves unacceptably toward you or another individual, please contact Charlotte Spencer at <a href="mailto:charlottelaspencer@gmail.com">charlottelaspencer[at]gmail[dot]com</a>


### PR DESCRIPTION
Basically some rewording and use of the [Angular CoC](https://github.com/angular/code-of-conduct) and [Conf Code of Conduct](http://confcodeofconduct.com/). This CoC will be committed to all past and future projects and will evolve as necessary.